### PR TITLE
Синхронизировать линтеры и git-hooks с проектом claude-config-main

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,65 @@
+# Markdownlint configuration for claude-config-template
+# Strategy: disable/relax rules that conflict with established repo style;
+# keep rules that catch real regressions (broken heading structure,
+# bad link syntax, wrong list numbering, etc.).
+
 default: true
 
-MD013:
-  line_length: 120
+# MD013 — line length
+# OFF: agent and skill files use intentionally long single-line prompt
+# instructions that do not benefit from wrapping. Other rules remain active.
+MD013: false
+
+# MD022 — blanks around headings
+# OFF: agent and skill files use compact heading+list blocks as a deliberate
+# dense-prompt style. Enforcing this globally produces false positives.
+MD022: false
+
+# MD024 — duplicate heading text
+# Allow same-content headings at different nesting levels (e.g. page title
+# "# Commands" + section "## Commands" in commands/README.md).
+MD024:
+  allow_different_nesting: true
+
+# MD029 — ordered list prefix style
+# OFF: agent files use sequential numbering inside prose sections;
+# enforcing lazy 1/1/1 style breaks readability of multi-step instructions.
+MD029: false
+
+# MD031 — blank lines around fenced code blocks
+# OFF: agent and skill files embed fenced blocks inside tight list items and
+# table-like prose sections where surrounding blank lines break the layout.
+MD031: false
+
+# MD032 — blank lines around lists
+# OFF: agent/skill files use lists inside dense prompt blocks without
+# surrounding blank lines — disabled to match compact-prompt style.
+MD032: false
+
+# MD033 — inline HTML
+# OFF: some docs use HTML for formatting intentionally.
 MD033: false
+
+# MD036 — emphasis used instead of a heading
+# OFF: task files use **Type:**, **Size:**, **Status:** bold-label headers
+# in their frontmatter sections; this is the canonical task-writer format.
+MD036: false
+
+# MD040 — fenced code blocks should have a language specified
+# OFF: many agent and doc files use bare ``` blocks for plaintext output,
+# shell sessions, and pseudo-code without a meaningful language tag.
+MD040: false
+
+# MD041 — first line should be a top-level heading
+# OFF: agent files start with a prose role declaration, and command files
+# start with YAML frontmatter — neither pattern begins with a # heading.
+MD041: false
+
+# MD058 — blank lines around tables
+# OFF: agent files place tables immediately after section headings without
+# a blank line, matching the compact-prompt style throughout agents/.
+MD058: false
+
+# MD060 — fenced code block style
+# OFF: repo uses both backtick and tilde fences.
 MD060: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,36 @@ Full specification: [`docs/conventions.md`](docs/conventions.md).
 
 ---
 
+## Local checks and pre-push
+
+The `linting/` directory contains a `pre-push-check.sh` orchestrator that runs shellcheck,
+markdownlint, and yamllint — the same set as CI. Enable it so errors are caught before
+pushing.
+
+**Automatic setup** — running `make install` creates a symlink in `.git/hooks/pre-push`
+automatically. If you prefer manual setup:
+
+```bash
+cp linting/pre-push-check.sh .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+Run checks directly at any time:
+
+```bash
+bash linting/pre-push-check.sh
+```
+
+There is also an optional `prepare-commit-msg` hook that appends a list of staged files
+to the commit message:
+
+```bash
+cp linting/prepare-commit-msg-check.sh .git/hooks/prepare-commit-msg
+chmod +x .git/hooks/prepare-commit-msg
+```
+
+---
+
 ## CI
 
 GitHub Actions runs `scripts/lint_skills.py` on every push and PR.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ make lint
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/conventions.md`](docs/conventions.md) for
 the full workflow and frontmatter specification.
 
+## Local checks and pre-push
+
+The `linting/` directory provides a pre-push hook that runs the same checks as CI locally:
+shellcheck, markdownlint, and yamllint.
+
+**Enable the pre-push hook** — `make install` does this automatically by creating a symlink
+in `.git/hooks/`. To set it up manually:
+
+```bash
+cp linting/pre-push-check.sh .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+Run the checks directly without installing the hook:
+
+```bash
+bash linting/pre-push-check.sh
+```
+
+There is also a `prepare-commit-msg` hook that appends a file-change summary to your commit
+message. To activate it:
+
+```bash
+cp linting/prepare-commit-msg-check.sh .git/hooks/prepare-commit-msg
+chmod +x .git/hooks/prepare-commit-msg
+```
+
 ## CI
 
 GitHub Actions runs `scripts/lint_skills.py` on every push and PR — it verifies that every

--- a/README.ru.md
+++ b/README.ru.md
@@ -67,6 +67,33 @@ make lint
 
 Подробнее — в [`CONTRIBUTING.md`](CONTRIBUTING.md) и [`docs/conventions.md`](docs/conventions.md).
 
+## Локальные проверки и pre-push
+
+Директория `linting/` содержит хук pre-push, который запускает те же проверки, что и CI:
+shellcheck, markdownlint и yamllint.
+
+**Включить хук pre-push** — `make install` делает это автоматически, создавая симлинк
+в `.git/hooks/`. Ручная установка:
+
+```bash
+cp linting/pre-push-check.sh .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+Запустить проверки напрямую без установки хука:
+
+```bash
+bash linting/pre-push-check.sh
+```
+
+Также есть хук `prepare-commit-msg`, который дописывает список изменённых файлов
+в сообщение коммита. Активация:
+
+```bash
+cp linting/prepare-commit-msg-check.sh .git/hooks/prepare-commit-msg
+chmod +x .git/hooks/prepare-commit-msg
+```
+
 ## CI
 
 GitHub Actions запускает `scripts/lint_skills.py` на каждый push и PR — проверяет,

--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,28 @@ done
 log ""
 log "Done."
 
+# ---------------------------------------------------------------------------
+# Pre-push hook installation (optional)
+# ---------------------------------------------------------------------------
+GIT_HOOKS_DIR="$REPO/.git/hooks"
+PRE_PUSH_SRC="$REPO/linting/pre-push-check.sh"
+PRE_PUSH_DST="$GIT_HOOKS_DIR/pre-push"
+
+if [[ $UNINSTALL -eq 1 ]]; then
+  if [[ -L "$PRE_PUSH_DST" ]]; then
+    _current="$(readlink "$PRE_PUSH_DST")"
+    if [[ "$_current" == "$PRE_PUSH_SRC" ]]; then
+      run "rm '$PRE_PUSH_DST'"
+      log "[hooks] - pre-push symlink removed"
+    fi
+  fi
+else
+  if [[ -f "$PRE_PUSH_SRC" ]] && [[ -d "$GIT_HOOKS_DIR" ]]; then
+    log "[hooks]"
+    link_one "$PRE_PUSH_SRC" "$PRE_PUSH_DST"
+  fi
+fi
+
 # Remind the user to update LICENSE if it still contains the template placeholder name.
 if [[ $UNINSTALL -eq 0 ]] && grep -q "TODO (after fork)" "$REPO/LICENSE" 2>/dev/null; then
   log ""

--- a/install.sh
+++ b/install.sh
@@ -35,14 +35,14 @@ run() {
   if [[ $DRY_RUN -eq 1 ]]; then
     log "DRY: $*"
   else
-    eval "$@"
+    "$@"
   fi
 }
 
 ensure_dir() {
   local dir="$1"
   if [[ ! -d "$dir" ]]; then
-    run "mkdir -p '$dir'"
+    run mkdir -p "$dir"
   fi
 }
 
@@ -62,7 +62,7 @@ link_one() {
     log "  ! $dst exists and is not a symlink. Skipping."
     return
   fi
-  run "ln -s '$src' '$dst'"
+  run ln -s "$src" "$dst"
   log "  + $dst -> $src"
 }
 
@@ -72,7 +72,7 @@ unlink_one() {
     local current
     current="$(readlink "$dst")"
     if [[ "$current" == "$src" ]]; then
-      run "rm '$dst'"
+      run rm "$dst"
       log "  - $dst"
       return
     fi
@@ -131,7 +131,7 @@ if [[ $UNINSTALL -eq 1 ]]; then
   if [[ -L "$PRE_PUSH_DST" ]]; then
     _current="$(readlink "$PRE_PUSH_DST")"
     if [[ "$_current" == "$PRE_PUSH_SRC" ]]; then
-      run "rm '$PRE_PUSH_DST'"
+      run rm "$PRE_PUSH_DST"
       log "[hooks] - pre-push symlink removed"
     fi
   fi

--- a/linting/check_scripts/check_markdownlint_all.sh
+++ b/linting/check_scripts/check_markdownlint_all.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# ----------------------------------------
+# Markdown Code Style Checker (Full Project)
+#
+# Checks all Markdown files in the project for style issues using markdownlint.
+# Used in pre-push-check.sh
+#
+# Usage:
+#   ./check_markdownlint_all.sh
+# ----------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Collect .md files (excluding generated/vendored directories)
+MD_FILES=$(find "$PROJECT_DIR" -name "*.md" \
+  -not -path "*/_site/*" \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.git/*")
+
+if [ -z "$MD_FILES" ]; then
+  echo "No Markdown files found"
+  exit 0
+fi
+
+# shellcheck disable=SC2086
+markdownlint $MD_FILES

--- a/linting/check_scripts/check_shellcheck_all.sh
+++ b/linting/check_scripts/check_shellcheck_all.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# ----------------------------------------
+# Shell Script Checker (Full Project)
+#
+# Checks all shell scripts in the project for issues using ShellCheck.
+# Used in pre-push-check.sh
+#
+# Usage:
+#   ./check_shellcheck_all.sh
+# ----------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Collect .sh files (excluding generated/vendored directories)
+SH_FILES=$(find "$PROJECT_DIR" -name "*.sh" \
+  -not -path "*/_site/*" \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.git/*")
+
+if [ -z "$SH_FILES" ]; then
+  echo "No shell script files found"
+  exit 0
+fi
+
+# shellcheck disable=SC2086
+shellcheck $SH_FILES

--- a/linting/check_scripts/check_yamllint_all.sh
+++ b/linting/check_scripts/check_yamllint_all.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# ----------------------------------------
+# YAML Code Style Checker (Full Project)
+#
+# Checks all YAML files in the project for style issues using yamllint.
+# Used in pre-push-check.sh
+#
+# Usage:
+#   ./check_yamllint_all.sh
+# ----------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Collect .yml/.yaml files (excluding generated/vendored directories)
+YAML_FILES=$(find "$PROJECT_DIR" -type f \( -name "*.yml" -o -name "*.yaml" \) \
+  -not -path "*/_site/*" \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.git/*")
+
+if [ -z "$YAML_FILES" ]; then
+  echo "No YAML files found"
+  exit 0
+fi
+
+# shellcheck disable=SC2086
+yamllint $YAML_FILES

--- a/linting/pre-push-check.sh
+++ b/linting/pre-push-check.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Pre-push hook orchestrator.
+# Run this script as .git/hooks/pre-push (see install.sh or README for setup).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "ShellCheck..."
+bash "$SCRIPT_DIR/check_scripts/check_shellcheck_all.sh"
+echo "----------"
+
+echo "Markdown Code Style Checker..."
+bash "$SCRIPT_DIR/check_scripts/check_markdownlint_all.sh"
+echo "----------"
+
+echo "YML/YAML Checker..."
+bash "$SCRIPT_DIR/check_scripts/check_yamllint_all.sh"
+echo "----------"
+
+# Optional checks — only run if the scripts are present
+script="$SCRIPT_DIR/check_scripts/check_htmlhint_all.sh"
+if [ -f "$script" ]; then
+  echo "HTML Code Checker..."
+  bash "$script"
+  echo "----------"
+fi
+
+script="$SCRIPT_DIR/check_scripts/check_stylelint_all.sh"
+if [ -f "$script" ]; then
+  echo "CSS Code Style Checker..."
+  bash "$script"
+  echo "----------"
+fi

--- a/linting/preparation/add_files_in_commit_message.sh
+++ b/linting/preparation/add_files_in_commit_message.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Appends the list of staged files to the commit message.
+# Called by prepare-commit-msg-check.sh
+
+COMMIT_MSG_FILE=".git/COMMIT_EDITMSG"
+
+if grep -qE '^Merge' "$COMMIT_MSG_FILE"; then
+  exit 0
+fi
+
+CHANGES=$(git diff --cached --name-status)
+[ -z "$CHANGES" ] && exit 0
+
+{
+  echo ""
+  echo "------------------------------"
+  echo "Files:"
+
+  echo "$CHANGES" | while read -r STATUS FILE1 FILE2; do
+    case "$STATUS" in
+      A) echo "Added:    $FILE1" ;;
+      M) echo "Changed:  $FILE1" ;;
+      D) echo "Deleted:  $FILE1" ;;
+      R*) echo "Renamed: $FILE1 -> $FILE2" ;;
+      *) echo "$STATUS:  $FILE1" ;;
+    esac
+  done
+} >> "$COMMIT_MSG_FILE"

--- a/linting/prepare-commit-msg-check.sh
+++ b/linting/prepare-commit-msg-check.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# prepare-commit-msg hook: appends the list of staged files to the commit message.
+# To activate: cp linting/prepare-commit-msg-check.sh .git/hooks/prepare-commit-msg && chmod +x .git/hooks/prepare-commit-msg
+
+set -euo pipefail
+
+bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/preparation/add_files_in_commit_message.sh"

--- a/scripts/lint_skills.py
+++ b/scripts/lint_skills.py
@@ -5,9 +5,9 @@ Checks:
 - file starts with a YAML frontmatter delimited by ---
 - has required keys (`name`, `description`)
 - `description` length is within Claude's limit (1024 chars)
-- `name` matches the directory name (for skills) or file stem (for agents)
+- `name` matches the directory name (for skills) or file stem (for agents) — ERROR if mismatched
 - no hardcoded values (absolute paths, emails, tokens) in skills/, agents/,
-  commands/, and hooks/ files
+  commands/, and hooks/ files (warnings)
 
 Usage:
   python3 scripts/lint_skills.py           # warnings are informational only
@@ -127,7 +127,7 @@ def check_skill(path: Path) -> None:
         )
     expected = path.parent.name
     if fm.get("name") and fm["name"] != expected:
-        warnings.append(
+        errors.append(
             f"{rel}: frontmatter name '{fm['name']}' != directory '{expected}'"
         )
 
@@ -144,7 +144,7 @@ def check_agent(path: Path) -> None:
             errors.append(f"{rel}: missing required key '{key}'")
     expected = path.stem
     if fm.get("name") and fm["name"] != expected:
-        warnings.append(
+        errors.append(
             f"{rel}: frontmatter name '{fm['name']}' != filename '{expected}'"
         )
 


### PR DESCRIPTION
## Summary

- Portированы `linting/` из `claude-config-main` (pre-push orchestrator, prepare-commit-msg, per-linter `_all.sh` runners, commit-message file-list helper) с устранением bug main (guard `[ -f ... ]` на отсутствующие htmlhint/stylelint runners).
- `.markdownlint.yml` расширен до набора правил из main; комментарии переписаны в нейтральных формулировках (без числовых метрик).
- `scripts/lint_skills.py` теперь поднимает несовпадение `name` до уровня ERROR.
- `install.sh` линкует `linting/pre-push-check.sh` в `.git/hooks/pre-push`; `eval "$@"` в хелпере `run()` заменён на прямой массив (SC2294).
- README и CONTRIBUTING описывают, как включить pre-push локально.

## Changes

- issues-4|drop eval from install.sh run helper to fix SC2294
- issues-4|document local pre-push checks in README and CONTRIBUTING
- issues-4|symlink linting/pre-push-check.sh on install
- issues-4|raise lint_skills.py name mismatch to error
- issues-4|extend markdownlint config to match claude-config-main
- issues-4|add helper to append file list to commit messages
- issues-4|add pre-push and prepare-commit-msg orchestrators
- issues-4|add per-linter check_*_all.sh runners under linting/

Closes #4