### PR TITLE
Добавить ruff, shfmt и codespell в CI и pre-push

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+# Exclude directories that may contain intentional non-English words or generated content
+skip = tasks,.git
+# Add false-positive words here (comma-separated), e.g.:
+# ignore-words-list = foo,ba

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -135,3 +135,63 @@ jobs:
             echo "yamllint found issues!"
             exit 1
           fi
+
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run ruff
+        run: |
+          set -euo pipefail
+          py_files=$(find scripts/ -name "*.py" -not -path "*/__pycache__/*")
+          if [ -z "$py_files" ]; then
+            echo "No Python files found in scripts/. Skipping."
+            exit 0
+          fi
+          # shellcheck disable=SC2086
+          ruff check $py_files
+
+  shfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shfmt
+        run: |
+          curl -sSL https://github.com/mvdan/sh/releases/download/v3.10.0/shfmt_v3.10.0_linux_amd64 \
+            -o /usr/local/bin/shfmt
+          chmod +x /usr/local/bin/shfmt
+          shfmt --version
+      - name: Run shfmt
+        run: |
+          set -euo pipefail
+          # Scope: linting/**/*.sh, excluding linting/preparation/ (pre-existing violations).
+          # Baseline suppressions: install.sh, scripts/*.sh, and linting/preparation/*.sh
+          # have pre-existing formatting violations. See follow-up tasks for fixes.
+          sh_files=$(find linting/ -name "*.sh" \
+            -not -path "*/preparation/*" \
+            -not -path "./_site/*" \
+            -not -path "./node_modules/*" \
+            -not -path "./.git/*")
+          if [ -z "$sh_files" ]; then
+            echo "No shell script files found in linting/. Skipping."
+            exit 0
+          fi
+          # shellcheck disable=SC2086
+          shfmt -d -i 2 -ci $sh_files
+
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install codespell
+        run: pip install codespell
+      - name: Run codespell
+        run: codespell skills/ agents/ docs/ README.md README.ru.md CONTRIBUTING.md

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,12 @@
+# ruff configuration for claude-config-template
+# Scope: scripts/ only (Python utilities)
+# Rules: ruff defaults (E, F)
+# To add suppressions for follow-up violations, use per-file-ignores or extend-ignore below.
+
+[lint]
+# Default rule sets: E (pycodestyle errors), F (pyflakes) — ruff built-in defaults.
+# Do not add I, UP, B here; those belong to a follow-up task.
+
+[lint.per-file-ignores]
+# Add file-specific ignores here if baseline violations surface, e.g.:
+# "scripts/lint_skills.py" = ["E501"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,16 @@ Full specification: [`docs/conventions.md`](docs/conventions.md).
 ## Local checks and pre-push
 
 The `linting/` directory contains a `pre-push-check.sh` orchestrator that runs shellcheck,
-markdownlint, and yamllint — the same set as CI. Enable it so errors are caught before
-pushing.
+markdownlint, yamllint, ruff, shfmt, and codespell — the same set as CI. Enable it so errors
+are caught before pushing.
+
+Install the additional linters before your first push:
+
+```bash
+pip install ruff codespell          # Python linter + spell checker
+brew install shfmt                  # shell formatter (macOS)
+# Linux / no brew: go install mvdan.cc/sh/v3/cmd/shfmt@latest
+```
 
 **Automatic setup** — running `make install` creates a symlink in `.git/hooks/pre-push`
 automatically. If you prefer manual setup:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ is added by you.
 | `claude` CLI | any | runtime environment |
 | Python | 3.12+ | `scripts/lint_skills.py` and CI |
 | `gh` CLI | any | optional, useful for GitHub-integrated skills |
+| `ruff` | any | Python linter (`pip install ruff`) |
+| `shfmt` | any | shell formatter (`brew install shfmt` or `go install mvdan.cc/sh/v3/cmd/shfmt@latest`) |
+| `codespell` | any | spell checker for docs (`pip install codespell`) |
 
 ## Structure
 
@@ -72,7 +75,7 @@ the full workflow and frontmatter specification.
 ## Local checks and pre-push
 
 The `linting/` directory provides a pre-push hook that runs the same checks as CI locally:
-shellcheck, markdownlint, and yamllint.
+shellcheck, markdownlint, yamllint, ruff (Python), shfmt (shell formatter), and codespell (spell check).
 
 **Enable the pre-push hook** — `make install` does this automatically by creating a symlink
 in `.git/hooks/`. To set it up manually:

--- a/README.ru.md
+++ b/README.ru.md
@@ -16,6 +16,9 @@
 | `claude` CLI | любая | основная среда исполнения |
 | Python | 3.12+ | `scripts/lint_skills.py` и CI |
 | `gh` CLI | любая | опционально, для скилов с интеграцией GitHub |
+| `ruff` | любая | линтер Python (`pip install ruff`) |
+| `shfmt` | любая | форматтер bash-скриптов (`brew install shfmt` или `go install mvdan.cc/sh/v3/cmd/shfmt@latest`) |
+| `codespell` | любая | проверка опечаток в документации (`pip install codespell`) |
 
 ## Структура
 
@@ -70,7 +73,7 @@ make lint
 ## Локальные проверки и pre-push
 
 Директория `linting/` содержит хук pre-push, который запускает те же проверки, что и CI:
-shellcheck, markdownlint и yamllint.
+shellcheck, markdownlint, yamllint, ruff (линтер Python), shfmt (форматтер bash) и codespell (проверка опечаток).
 
 **Включить хук pre-push** — `make install` делает это автоматически, создавая симлинк
 в `.git/hooks/`. Ручная установка:

--- a/linting/check_scripts/check_codespell_all.sh
+++ b/linting/check_scripts/check_codespell_all.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# ----------------------------------------
+# Spell Checker (Full Project)
+#
+# Checks for spelling mistakes in documentation files using codespell.
+# Config: .codespellrc in project root.
+# Scope: skills/, agents/, docs/, README.md, README.ru.md, CONTRIBUTING.md
+# Excluded: tasks/, .git/
+# Used in pre-push-check.sh
+#
+# Usage:
+#   ./check_codespell_all.sh
+#
+# Requires: codespell (pip install codespell)
+# ----------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if ! command -v codespell &>/dev/null; then
+  echo "ERROR: codespell is not installed. Install it with: pip install codespell" >&2
+  exit 1
+fi
+
+# Run codespell on explicitly listed paths.
+# .codespellrc in project root provides skip and ignore-words-list config.
+# We cd into PROJECT_DIR so .codespellrc is picked up automatically.
+cd "$PROJECT_DIR"
+codespell skills/ agents/ docs/ README.md README.ru.md CONTRIBUTING.md

--- a/linting/check_scripts/check_ruff_all.sh
+++ b/linting/check_scripts/check_ruff_all.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# ----------------------------------------
+# Python Linter (Full Project)
+#
+# Checks all Python scripts in scripts/ using ruff (rules: E, F — ruff defaults).
+# Config: .ruff.toml in project root.
+# Used in pre-push-check.sh
+#
+# Usage:
+#   ./check_ruff_all.sh
+#
+# Requires: ruff (pip install ruff)
+# ----------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if ! command -v ruff &>/dev/null; then
+  echo "ERROR: ruff is not installed. Install it with: pip install ruff" >&2
+  exit 1
+fi
+
+PY_FILES=$(find "$PROJECT_DIR/scripts" -name "*.py" \
+  -not -path "*/__pycache__/*")
+
+if [ -z "$PY_FILES" ]; then
+  echo "No Python files found in scripts/"
+  exit 0
+fi
+
+# shellcheck disable=SC2086
+ruff check $PY_FILES

--- a/linting/check_scripts/check_shfmt_all.sh
+++ b/linting/check_scripts/check_shfmt_all.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# ----------------------------------------
+# Shell Script Formatter Check (Full Project)
+#
+# Checks shell script formatting using shfmt.
+# Indent style: 2 spaces (-i 2), case indent (-ci).
+# Determined by surveying existing scripts in this repo (2-space indent dominates).
+#
+# Scope: linting/**/*.sh only.
+# Baseline suppressions: install.sh and scripts/*.sh are excluded because they contain
+# pre-existing formatting violations. Follow-up task required to reformat those files.
+#
+# Used in pre-push-check.sh
+#
+# Usage:
+#   ./check_shfmt_all.sh
+#
+# Requires: shfmt (brew install shfmt  OR  go install mvdan.cc/sh/v3/cmd/shfmt@latest
+#                  OR  curl binary download from https://github.com/mvdan/sh/releases)
+# ----------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if ! command -v shfmt &>/dev/null; then
+  echo "ERROR: shfmt is not installed." >&2
+  echo "  Install with: brew install shfmt" >&2
+  echo "  Or:           go install mvdan.cc/sh/v3/cmd/shfmt@latest" >&2
+  echo "  Or: curl binary from https://github.com/mvdan/sh/releases" >&2
+  exit 1
+fi
+
+# Collect shell scripts in scope.
+# Baseline: linting/check_scripts/*.sh and linting/*.sh (pre-push-check, prepare-commit-msg).
+# Excluded from baseline (pre-existing violations, tracked in follow-up tasks):
+#   - install.sh
+#   - scripts/*.sh
+#   - linting/preparation/*.sh (add_files_in_commit_message.sh: space-around-> violation)
+SH_FILES=$(find "$PROJECT_DIR/linting" -name "*.sh" \
+  -not -path "*/preparation/*" \
+  -not -path "*/_site/*" \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.git/*")
+
+if [ -z "$SH_FILES" ]; then
+  echo "No shell script files found in linting/"
+  exit 0
+fi
+
+# shellcheck disable=SC2086
+shfmt -d -i 2 -ci $SH_FILES

--- a/linting/pre-push-check.sh
+++ b/linting/pre-push-check.sh
@@ -18,6 +18,18 @@ echo "YML/YAML Checker..."
 bash "$SCRIPT_DIR/check_scripts/check_yamllint_all.sh"
 echo "----------"
 
+echo "Python Linter (ruff)..."
+bash "$SCRIPT_DIR/check_scripts/check_ruff_all.sh"
+echo "----------"
+
+echo "Shell Formatter (shfmt)..."
+bash "$SCRIPT_DIR/check_scripts/check_shfmt_all.sh"
+echo "----------"
+
+echo "Spell Checker (codespell)..."
+bash "$SCRIPT_DIR/check_scripts/check_codespell_all.sh"
+echo "----------"
+
 # Optional checks — only run if the scripts are present
 script="$SCRIPT_DIR/check_scripts/check_htmlhint_all.sh"
 if [ -f "$script" ]; then


### PR DESCRIPTION
## Summary

Добавлены три независимых линтера параллельно существующим ShellCheck / markdownlint / yamllint — одинаково в CI (`.github/workflows/lint.yml`) и в локальном `linting/pre-push-check.sh`:

- **ruff** — проверяет `scripts/*.py`; конфиг `.ruff.toml` с дефолтными правилами (`E`, `F`); baseline зелёный без suppressions.
- **shfmt** — проверяет bash-скрипты флагами `-d -i 2 -ci` (2-space indent подтверждён подсчётом по `install.sh` и `linting/*.sh`). Baseline scope: `linting/check_scripts/*.sh`, `linting/pre-push-check.sh`, `linting/prepare-commit-msg-check.sh`. В CI — установка бинаря прямой загрузкой из релиза `mvdan/sh` (без `actions/setup-go` и сторонних actions).
- **codespell** — проверяет `skills/`, `agents/`, `docs/`, `README.md`, `README.ru.md`, `CONTRIBUTING.md`; `tasks/` и `.git/` исключены; baseline зелёный.

Pre-push fail-hard policy (по ТЗ): если бинарь не установлен, скрипт печатает инструкцию и возвращает non-zero (не silently skip).

## Follow-ups

Из shfmt baseline исключены из-за pre-existing violations (не фиксим в scope этой задачи):

- `install.sh` — форматирование `case`-веток, `cat >` spacing
- `scripts/doctor.sh` — alignment `ok()`, разворот single-line `fail()`, `> /dev/null` → `>/dev/null`
- `scripts/new_skill.sh` — `cat >` spacing
- `linting/preparation/add_files_in_commit_message.sh` — `} >>` → `}>>`

Каждый из этих файлов — кандидат на отдельный follow-up.

## Changes

- issues-6|add ruff config and pre-push check for scripts/
- issues-6|add shfmt pre-push check with -i 2 -ci flags
- issues-6|add codespell config and pre-push check for docs
- issues-6|wire ruff, shfmt, codespell into pre-push orchestrator
- issues-6|add ruff, shfmt, codespell jobs to lint workflow
- issues-6|document ruff, shfmt, codespell in README and CONTRIBUTING

Closes #6