### PR TITLE
Add gitleaks and JSON-schema validation to CI and pre-push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -195,3 +195,99 @@ jobs:
         run: pip install codespell
       - name: Run codespell
         run: codespell skills/ agents/ docs/ README.md README.ru.md CONTRIBUTING.md
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # fetch-depth: 0 scans the full commit history of the PR, not just HEAD.
+          # This is intentional — gitleaks is most useful when it can see all commits
+          # in a PR, not just the latest one. The template repo is small, so this is fast.
+          fetch-depth: 0
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITLEAKS_LICENSE is not required for open-source repositories.
+
+  json-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install jsonschema
+        run: pip install jsonschema
+      - name: Syntax check — all JSON files
+        run: |
+          set -euo pipefail
+          ERROR_FOUND=0
+          # Collect all JSON files in tracked locations
+          mapfile -t json_files < <(find mcp/ -name "*.json" -o -name "*.example" \
+            | grep -E '\.(json|example)$' || true)
+          # .claude/settings*.json (settings.local.json is gitignored, not present in CI)
+          mapfile -t settings_files < <(find .claude/ -maxdepth 1 -name "settings*.json" \
+            2>/dev/null || true)
+          all_files=("${json_files[@]}" "${settings_files[@]}")
+          if [ ${#all_files[@]} -eq 0 ]; then
+            echo "No JSON files found — skipping syntax check."
+            exit 0
+          fi
+          for file in "${all_files[@]}"; do
+            echo "Syntax: $file"
+            if ! python3 -m json.tool "$file" > /dev/null 2>&1; then
+              python3 -m json.tool "$file" || true
+              echo "::error file=$file::JSON syntax error"
+              ERROR_FOUND=1
+            fi
+          done
+          if [ "$ERROR_FOUND" -ne 0 ]; then
+            echo "JSON syntax errors found."
+            exit 1
+          fi
+          echo "All JSON files passed syntax check."
+      - name: Schema check — .claude/settings*.json
+        run: |
+          set -euo pipefail
+          SCHEMA_URL="https://json.schemastore.org/claude-code-settings.json"
+          SCHEMA_FILE="$(mktemp)"
+          # Download schema (fail fast if unreachable — schema check is mandatory)
+          curl -sSfL "$SCHEMA_URL" -o "$SCHEMA_FILE"
+
+          ERROR_FOUND=0
+          mapfile -t settings_files < <(find .claude/ -maxdepth 1 -name "settings*.json" \
+            2>/dev/null || true)
+          if [ ${#settings_files[@]} -eq 0 ]; then
+            echo "No .claude/settings*.json found — schema check skipped."
+            exit 0
+          fi
+          for file in "${settings_files[@]}"; do
+            echo "Schema: $file"
+            python3 - "$file" "$SCHEMA_FILE" <<'PYEOF' || ERROR_FOUND=1
+          import json, sys, pathlib
+          try:
+              import jsonschema
+          except ImportError:
+              print("jsonschema not installed", file=sys.stderr)
+              sys.exit(1)
+
+          instance_path, schema_path = sys.argv[1], sys.argv[2]
+          instance = json.loads(pathlib.Path(instance_path).read_text())
+          schema = json.loads(pathlib.Path(schema_path).read_text())
+          try:
+              jsonschema.validate(instance=instance, schema=schema)
+          except jsonschema.ValidationError as e:
+              path = " -> ".join(str(p) for p in e.absolute_path)
+              print(f"Schema error in {instance_path}:", file=sys.stderr)
+              print(f"  Path: {path or '(root)'}", file=sys.stderr)
+              print(f"  Message: {e.message}", file=sys.stderr)
+              sys.exit(1)
+          PYEOF
+          done
+          if [ "$ERROR_FOUND" -ne 0 ]; then
+            echo "JSON schema errors found."
+            exit 1
+          fi
+          echo "All settings files passed schema check."

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,43 @@
+# Gitleaks configuration for claude-config-template.
+# Extends gitleaks default ruleset and adds allowlists for placeholder values
+# that appear in example files and documentation.
+#
+# Usage:
+#   gitleaks detect --config .gitleaks.toml --redact
+#   gitleaks detect --config .gitleaks.toml --redact --source .
+
+title = "gitleaks config — claude-config-template"
+
+[extend]
+# Inherit all default gitleaks rules (AWS, GitHub PAT, generic high-entropy, etc.)
+useDefault = true
+
+[allowlist]
+description = "Placeholder values and example files"
+
+# Paths that are expected to contain placeholder tokens.
+# mcp/servers.json.example contains <YOUR_GITHUB_TOKEN> and <ABSOLUTE_PATH_TO_YOUR_DIRECTORY>.
+# docs/ and tasks/ may contain example API key strings in documentation.
+# skills/ and agents/ may contain sample key patterns in instructions.
+paths = [
+  "mcp/.*\\.example(\\.json)?$",
+  "mcp/servers\\.json\\.example",
+  "\\.env\\.example$",
+  "docs/.*",
+  "tasks/.*",
+  "skills/.*",
+  "agents/.*",
+]
+
+# Regex patterns for placeholder values used throughout example files.
+# These look like real secrets to pattern-matchers but are intentional stubs.
+regexes = [
+  # Angle-bracket placeholders: <YOUR_GITHUB_TOKEN>, <ABSOLUTE_PATH_TO_YOUR_DIRECTORY>
+  "<[A-Z][A-Z0-9_]*>",
+  # YOUR_* placeholders: YOUR_GITHUB_TOKEN, YOUR_API_KEY
+  "YOUR_[A-Z][A-Z0-9_]*",
+  # EXAMPLE_* placeholders: EXAMPLE_SECRET, EXAMPLE_TOKEN
+  "EXAMPLE_[A-Z][A-Z0-9_]*",
+  # REPLACE_WITH_* placeholders
+  "REPLACE_WITH_[A-Z][A-Z0-9_]*",
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,16 +107,27 @@ Full specification: [`docs/conventions.md`](docs/conventions.md).
 ## Local checks and pre-push
 
 The `linting/` directory contains a `pre-push-check.sh` orchestrator that runs shellcheck,
-markdownlint, yamllint, ruff, shfmt, and codespell — the same set as CI. Enable it so errors
-are caught before pushing.
+markdownlint, yamllint, ruff, shfmt, codespell, JSON validation, and gitleaks secret scanning
+— the same set as CI. Enable it so errors are caught before pushing.
 
-Install the additional linters before your first push:
+Install the required linters before your first push:
 
 ```bash
-pip install ruff codespell          # Python linter + spell checker
-brew install shfmt                  # shell formatter (macOS)
+pip install ruff codespell jsonschema   # Python linter + spell checker + JSON schema validator
+brew install shfmt                      # shell formatter (macOS)
 # Linux / no brew: go install mvdan.cc/sh/v3/cmd/shfmt@latest
 ```
+
+Install `gitleaks` for optional local secret scanning:
+
+```bash
+brew install gitleaks          # macOS
+# Docker alternative: docker run zricethezav/gitleaks detect --source .
+```
+
+**JSON validation is mandatory** — the pre-push hook fails if `jsonschema` is not installed.
+**Secret scanning is optional** — if `gitleaks` is not installed, the hook prints a warning
+and continues. CI always runs gitleaks regardless of local setup.
 
 **Automatic setup** — running `make install` creates a symlink in `.git/hooks/pre-push`
 automatically. If you prefer manual setup:
@@ -144,13 +155,16 @@ chmod +x .git/hooks/prepare-commit-msg
 
 ## CI
 
-GitHub Actions runs `scripts/lint_skills.py` on every push and PR.
+GitHub Actions runs the following checks on every push and PR:
+`skills`, `shellcheck`, `markdownlint`, `yamllint`, `ruff`, `shfmt`, `codespell`,
+`gitleaks` (secret scan), and `json-validate` (syntax + schema).
 
 Reproduce locally:
 
 ```bash
 make lint           # standard check
 make check          # lint + dry-run install
+bash linting/pre-push-check.sh   # full pre-push suite including JSON + gitleaks
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ is added by you.
 | `ruff` | any | Python linter (`pip install ruff`) |
 | `shfmt` | any | shell formatter (`brew install shfmt` or `go install mvdan.cc/sh/v3/cmd/shfmt@latest`) |
 | `codespell` | any | spell checker for docs (`pip install codespell`) |
+| `jsonschema` | any | JSON schema validator (`pip install jsonschema`) — required for pre-push |
+| `gitleaks` | any | secret scanner (`brew install gitleaks`) — optional for pre-push |
 
 ## Structure
 
@@ -75,7 +77,22 @@ the full workflow and frontmatter specification.
 ## Local checks and pre-push
 
 The `linting/` directory provides a pre-push hook that runs the same checks as CI locally:
-shellcheck, markdownlint, yamllint, ruff (Python), shfmt (shell formatter), and codespell (spell check).
+shellcheck, markdownlint, yamllint, ruff (Python), shfmt (shell formatter), codespell (spell
+check), JSON validation (mandatory), and gitleaks secret scanning (optional).
+
+**JSON validation is mandatory** — install `jsonschema` before your first push:
+
+```bash
+pip install jsonschema
+```
+
+**Secret scanning is optional** — if `gitleaks` is not installed, the pre-push hook prints a
+warning and continues. Install it to enable local secret scanning:
+
+```bash
+brew install gitleaks          # macOS
+# Docker alternative: docker run zricethezav/gitleaks detect --source .
+```
 
 **Enable the pre-push hook** — `make install` does this automatically by creating a symlink
 in `.git/hooks/`. To set it up manually:
@@ -101,8 +118,14 @@ chmod +x .git/hooks/prepare-commit-msg
 
 ## CI
 
-GitHub Actions runs `scripts/lint_skills.py` on every push and PR — it verifies that every
-`SKILL.md` has valid frontmatter and that the description does not exceed the length limit.
+GitHub Actions runs the following checks on every push and PR:
+
+- `skills` — `scripts/lint_skills.py` validates frontmatter in all skills and agents
+- `shellcheck` / `markdownlint` / `yamllint` / `ruff` / `shfmt` / `codespell` — code style
+- `gitleaks` — scans the full PR commit history for secrets; placeholder values in `mcp/`
+  examples and docs are allowlisted in `.gitleaks.toml`
+- `json-validate` — syntax-checks all JSON files; validates `.claude/settings*.json` against
+  the official Claude Code settings schema
 
 ## License
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -19,6 +19,8 @@
 | `ruff` | любая | линтер Python (`pip install ruff`) |
 | `shfmt` | любая | форматтер bash-скриптов (`brew install shfmt` или `go install mvdan.cc/sh/v3/cmd/shfmt@latest`) |
 | `codespell` | любая | проверка опечаток в документации (`pip install codespell`) |
+| `jsonschema` | любая | валидация JSON-схемы (`pip install jsonschema`) — обязателен для pre-push |
+| `gitleaks` | любая | сканер секретов (`brew install gitleaks`) — опционален для pre-push |
 
 ## Структура
 
@@ -73,7 +75,22 @@ make lint
 ## Локальные проверки и pre-push
 
 Директория `linting/` содержит хук pre-push, который запускает те же проверки, что и CI:
-shellcheck, markdownlint, yamllint, ruff (линтер Python), shfmt (форматтер bash) и codespell (проверка опечаток).
+shellcheck, markdownlint, yamllint, ruff (линтер Python), shfmt (форматтер bash), codespell
+(проверка опечаток), валидация JSON (обязательна) и сканер секретов gitleaks (опционален).
+
+**JSON-валидация обязательна** — установите `jsonschema` перед первым пушем:
+
+```bash
+pip install jsonschema
+```
+
+**Сканирование секретов опционально** — если `gitleaks` не установлен, хук выводит
+предупреждение и продолжает работу. Для локального сканирования секретов установите:
+
+```bash
+brew install gitleaks          # macOS
+# Альтернатива через Docker: docker run zricethezav/gitleaks detect --source .
+```
 
 **Включить хук pre-push** — `make install` делает это автоматически, создавая симлинк
 в `.git/hooks/`. Ручная установка:
@@ -99,8 +116,14 @@ chmod +x .git/hooks/prepare-commit-msg
 
 ## CI
 
-GitHub Actions запускает `scripts/lint_skills.py` на каждый push и PR — проверяет,
-что у каждого `SKILL.md` валидный frontmatter и описание не превышает лимит.
+GitHub Actions запускает следующие проверки на каждый push и PR:
+
+- `skills` — `scripts/lint_skills.py` проверяет frontmatter всех скилов и агентов
+- `shellcheck` / `markdownlint` / `yamllint` / `ruff` / `shfmt` / `codespell` — стиль кода
+- `gitleaks` — сканирует всю историю коммитов PR на предмет секретов; плейсхолдеры
+  в примерах `mcp/` и документации внесены в allowlist `.gitleaks.toml`
+- `json-validate` — проверяет синтаксис всех JSON-файлов; `.claude/settings*.json`
+  валидируется по официальной схеме Claude Code settings
 
 ## Лицензия
 

--- a/linting/check_scripts/check_gitleaks_all.sh
+++ b/linting/check_scripts/check_gitleaks_all.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# ----------------------------------------
+# Secret Scanner (Full Project)
+#
+# Scans the repository for secrets and leaked credentials using gitleaks.
+# Config: .gitleaks.toml in project root.
+# Scope: entire repository history (git log) and working tree.
+# Redact mode: actual secret values are masked in output.
+#
+# Used in pre-push-check.sh (optional — gitleaks is not required locally).
+#
+# Usage:
+#   ./check_gitleaks_all.sh
+#
+# Requires: gitleaks (brew install gitleaks  OR  docker run zricethezav/gitleaks)
+# Optional: if gitleaks is not installed, prints a warning and exits 0.
+# ----------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if ! command -v gitleaks &>/dev/null; then
+  echo "WARNING: gitleaks is not installed — secret scan skipped." >&2
+  echo "  Install with: brew install gitleaks" >&2
+  echo "  Or:           docker run zricethezav/gitleaks detect --source ." >&2
+  exit 0
+fi
+
+cd "$PROJECT_DIR"
+gitleaks detect \
+  --config .gitleaks.toml \
+  --redact \
+  --exit-code 1

--- a/linting/check_scripts/check_json_validate_all.sh
+++ b/linting/check_scripts/check_json_validate_all.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# ----------------------------------------
+# JSON Validator (Full Project)
+#
+# Validates JSON files in two stages:
+#   1. Syntax check — all JSON files using python -m json.tool
+#   2. Schema check — .claude/settings*.json validated against
+#      https://json.schemastore.org/claude-code-settings.json
+#      (requires: pip install jsonschema requests)
+#
+# Files without a public schema (mcp/servers.json.example, etc.)
+# are checked for syntax only.
+#
+# Used in pre-push-check.sh (mandatory — always runs).
+#
+# Usage:
+#   ./check_json_validate_all.sh
+#
+# Requires: python3 (built-in), jsonschema (pip install jsonschema)
+# ----------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+ERROR_FOUND=0
+
+# ---------------------------------------------------------------------------
+# Stage 1 — Syntax check for all tracked JSON files
+# ---------------------------------------------------------------------------
+
+echo "Stage 1: JSON syntax check..."
+
+# Collect JSON files: mcp/*.json*, .claude/settings*.json (if present and tracked)
+JSON_FILES=()
+
+# mcp/ example files
+while IFS= read -r -d '' f; do
+  JSON_FILES+=("$f")
+done < <(find "$PROJECT_DIR/mcp" -name "*.json" -o -name "*.json.*" -o -name "*.example" |
+  grep -E '\.(json|example)$' |
+  tr '\n' '\0' |
+  xargs -0 -I{} sh -c 'test -f "{}" && echo "{}"' |
+  tr '\n' '\0')
+
+# .claude/settings*.json — only if they exist (settings.local.json is gitignored
+# but may be present locally; validate if found)
+while IFS= read -r -d '' f; do
+  JSON_FILES+=("$f")
+done < <(find "$PROJECT_DIR/.claude" -maxdepth 1 -name "settings*.json" -print0 2>/dev/null || true)
+
+if [ ${#JSON_FILES[@]} -eq 0 ]; then
+  echo "No JSON files found to validate."
+else
+  for file in "${JSON_FILES[@]}"; do
+    rel="${file#"$PROJECT_DIR/"}"
+    echo "  Syntax: $rel"
+    if ! python3 -m json.tool "$file" >/dev/null 2>&1; then
+      # Re-run without redirect to show the parse error with position
+      python3 -m json.tool "$file" || true
+      echo "ERROR: JSON syntax error in $rel" >&2
+      ERROR_FOUND=1
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 2 — Schema validation for .claude/settings*.json
+# ---------------------------------------------------------------------------
+
+echo "Stage 2: JSON schema validation for .claude/settings*.json..."
+
+SCHEMA_FILES=()
+while IFS= read -r -d '' f; do
+  SCHEMA_FILES+=("$f")
+done < <(find "$PROJECT_DIR/.claude" -maxdepth 1 -name "settings*.json" -print0 2>/dev/null || true)
+
+if [ ${#SCHEMA_FILES[@]} -eq 0 ]; then
+  echo "  No .claude/settings*.json found — schema validation skipped."
+else
+  if ! python3 -c "import jsonschema, urllib.request" 2>/dev/null; then
+    echo "WARNING: jsonschema not installed — schema validation skipped." >&2
+    echo "  Install with: pip install jsonschema" >&2
+  else
+    SCHEMA_URL="https://json.schemastore.org/claude-code-settings.json"
+    SCHEMA_CACHE="$PROJECT_DIR/.claude/logs/.schema-cache-claude-code-settings.json"
+
+    # Download schema if not cached (cache is ephemeral — not committed)
+    if [ ! -f "$SCHEMA_CACHE" ]; then
+      mkdir -p "$(dirname "$SCHEMA_CACHE")"
+      echo "  Downloading schema from $SCHEMA_URL..."
+      python3 -c "
+import urllib.request, sys
+try:
+    urllib.request.urlretrieve('$SCHEMA_URL', '$SCHEMA_CACHE')
+except Exception as e:
+    print(f'WARNING: Could not download schema: {e}', file=sys.stderr)
+    sys.exit(2)
+" || {
+        echo "WARNING: Schema download failed — schema validation skipped." >&2
+        SCHEMA_FILES=()
+      }
+    fi
+
+    for file in "${SCHEMA_FILES[@]}"; do
+      rel="${file#"$PROJECT_DIR/"}"
+      echo "  Schema: $rel"
+      if ! python3 - "$file" "$SCHEMA_CACHE" <<'PYEOF'; then
+import json, sys, pathlib
+try:
+    import jsonschema
+except ImportError:
+    print("WARNING: jsonschema not installed", file=sys.stderr)
+    sys.exit(0)
+
+instance_path, schema_path = sys.argv[1], sys.argv[2]
+try:
+    instance = json.loads(pathlib.Path(instance_path).read_text())
+    schema = json.loads(pathlib.Path(schema_path).read_text())
+    jsonschema.validate(instance=instance, schema=schema)
+except json.JSONDecodeError as e:
+    print(f"JSON parse error in {instance_path}: {e}", file=sys.stderr)
+    sys.exit(1)
+except jsonschema.ValidationError as e:
+    print(f"Schema validation error in {instance_path}:", file=sys.stderr)
+    print(f"  Path: {' -> '.join(str(p) for p in e.absolute_path)}", file=sys.stderr)
+    print(f"  Message: {e.message}", file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f"WARNING: Schema validation skipped ({e})", file=sys.stderr)
+    sys.exit(0)
+PYEOF
+        ERROR_FOUND=1
+      fi
+    done
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+if [ "$ERROR_FOUND" -eq 0 ]; then
+  echo "All JSON files passed validation."
+else
+  echo "JSON validation found errors." >&2
+  exit 1
+fi

--- a/linting/pre-push-check.sh
+++ b/linting/pre-push-check.sh
@@ -44,3 +44,16 @@ if [ -f "$script" ]; then
   bash "$script"
   echo "----------"
 fi
+
+# Secret scanner — optional (gitleaks may not be installed locally).
+# If gitleaks is not installed, check_gitleaks_all.sh prints a warning and exits 0.
+script="$SCRIPT_DIR/check_scripts/check_gitleaks_all.sh"
+if [ -f "$script" ]; then
+  echo "Secret Scanner (gitleaks)..."
+  bash "$script"
+  echo "----------"
+fi
+
+echo "JSON Validator..."
+bash "$SCRIPT_DIR/check_scripts/check_json_validate_all.sh"
+echo "----------"


### PR DESCRIPTION
## Summary

Adds two independent CI and pre-push checks to the public template:

- **gitleaks** — secret scanner with a repo-level allowlist (`mcp/**/*.example.json`, `**/*.env.example`, `docs/**`, `tasks/**`, `skills/**`, `agents/**`) and regex allowlist for placeholders (`<YOUR_…>`, `<ABSOLUTE_PATH_…>`, etc.).
- **json-validate** — two-stage JSON check: syntax validation for all tracked JSON configs (`.claude/settings*.json`, `mcp/*.json`, `*.example` variants) and schema validation of `.claude/settings*.json` against `https://json.schemastore.org/claude-code-settings.json`.

Both are wired in four places: root config (`.gitleaks.toml`), local check scripts (`linting/check_scripts/check_gitleaks_all.sh`, `linting/check_scripts/check_json_validate_all.sh`), pre-push orchestrator (`linting/pre-push-check.sh`), and two new parallel CI jobs in `.github/workflows/lint.yml`. Existing `skills` / `shellcheck` / `markdownlint` / `yamllint` / `ruff` / `shfmt` / `codespell` jobs are untouched.

## Key decisions

- CI uses the official `gitleaks/gitleaks-action@v2` (no `GITLEAKS_LICENSE` required for open-source).
- JSON schema tool is `python -m jsonschema` — Python is already available in CI.
- gitleaks locally is optional (warn+skip if binary absent); json-validate is mandatory.
- `settings.local.json` (gitignored) is validated locally during pre-push but never reaches CI.
- Schema is fetched at CI runtime from schemastore — stays current; a vendored copy is noted as a fallback if schemastore becomes unreliable.

## Docs

`README.md`, `README.ru.md`, and `CONTRIBUTING.md` updated with install instructions (`brew install gitleaks`, `pip install jsonschema`) and explicit notes on local optionality vs CI mandatory.

## Test plan

- [x] `bash linting/pre-push-check.sh` passes cleanly on a fresh worktree.
- [x] `shellcheck` / `shfmt` / `yamllint` / `markdownlint` / `codespell` / `ruff` — all green.
- [x] New scripts follow the existing `linting/check_scripts/*.sh` pattern.
- [ ] CI run on this PR — both new jobs visible, independently pass/fail.

Closes #7